### PR TITLE
win32 msvc port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,15 @@ find_package(KDE4 REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(Sqlite REQUIRED)
 
+if (WIN32)
+find_package(Kdewin REQUIRED)
+endif()
+
 include_directories(${KDE4_INCLUDES})
+
+if (WIN32)
+add_definitions(-DWIN32)
+endif()
 
 if(DEBUG_PROFILE)
 add_definitions(-pg)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -58,8 +58,8 @@ kde4_add_ui_files(konstruktor_SRCS
 )
 
 kde4_add_executable(konstruktor ${konstruktor_SRCS})
-target_link_libraries(konstruktor libldrawrenderer ${SQLITE_LIBRARIES} ${KDE4_KDECORE_LIBS}
-${KDE4_KIO_LIBS} ${KDE4_KDEUI_LIBS} ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTOPENGL_LIBRARY})
+target_link_libraries(konstruktor libldr libldrawrenderer ${SQLITE_LIBRARIES} ${KDE4_KDECORE_LIBS}
+${KDE4_KIO_LIBS} ${KDE4_KDEUI_LIBS} ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTOPENGL_LIBRARY} )
 
 # Konstruktor DB Updater
 
@@ -75,7 +75,7 @@ kde4_add_kcfg_files(konstruktor_db_updater_SRCS config.kcfgc)
 
 kde4_add_executable(konstruktor_db_updater ${konstruktor_db_updater_SRCS})
 set_target_properties(konstruktor_db_updater PROPERTIES COMPILE_FLAGS -DKONSTRUKTOR_DB_UPDATER)
-target_link_libraries(konstruktor_db_updater libldrawrenderer ${SQLITE_LIBRARIES} ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTOPENGL_LIBRARY} ${KDE4_KDECORE_LIBRARY} ${KDE4_KDEUI_LIBRARY})
+target_link_libraries(konstruktor_db_updater libldr libldrawrenderer ${SQLITE_LIBRARIES} ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTOPENGL_LIBRARY} ${KDE4_KDECORE_LIBRARY} ${KDE4_KDEUI_LIBRARY})
 
 # install
 install(TARGETS konstruktor konstruktor_db_updater DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS})

--- a/src/app/renderwidget.cpp
+++ b/src/app/renderwidget.cpp
@@ -395,14 +395,14 @@ void RenderWidget::renderPointArray()
 		
 		glBegin(GL_POINTS);
 		
-		int i = 0;
+		int j = 0;
 		for (ldraw::model::const_iterator it = currentModel_->elements().begin(); it != currentModel_->elements().end(); ++it) {
 			if ((*it)->get_type() == ldraw::type_ref) {
 				ldraw::element_ref *r = CAST_AS_REF(*it);
 				ldraw::model *rm = r->get_model();
 				
 				if (rm) {
-					if (!tvset_->query(rm, i, 0)) {
+					if (!tvset_->query(rm, j, 0)) {
 						if (!rm->custom_data<ldraw::metrics>())
 							rm->init_custom_data<ldraw::metrics>();
 						
@@ -414,7 +414,7 @@ void RenderWidget::renderPointArray()
 					}				
 				}
 			}
-			++i;
+			++j;
 		}
 		
 		glEnd();

--- a/src/app/renderwidget.h
+++ b/src/app/renderwidget.h
@@ -4,6 +4,9 @@
 #ifndef _RENDERWIDGET_H_
 #define _RENDERWIDGET_H_
 
+#if defined(WIN32)
+#include <windows.h>
+#endif
 #include <GL/gl.h>
 
 #include <list>

--- a/src/app/selection.h
+++ b/src/app/selection.h
@@ -4,6 +4,10 @@
 #ifndef _SELECTION_H_
 #define _SELECTION_H_
 
+
+#if defined(WIN32)
+#include <windows.h>
+#endif
 #include <GL/gl.h>
 
 #include <list>

--- a/src/libldr/CMakeLists.txt
+++ b/src/libldr/CMakeLists.txt
@@ -28,11 +28,13 @@ set(libldr_HEADERS
   utils.h
   writer.h
 )
+include_directories(${KDEWIN_INCLUDES})
+add_definitions(-DMAKE_LIBLDR_LIB)
 
 add_library(libldr SHARED ${libldr_SOURCES})
 set_target_properties(libldr PROPERTIES OUTPUT_NAME ldraw)
 set_target_properties(libldr PROPERTIES VERSION 0.5.0 SOVERSION 1)
-
+target_link_libraries(libldr ${KDEWIN_LIBRARIES})
 # install
 install(TARGETS libldr DESTINATION ${INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES ${libldr_HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR}/libldr)

--- a/src/libldr/color.h
+++ b/src/libldr/color.h
@@ -43,8 +43,9 @@ struct material_traits_glitter
 	int size;
 };
 
-struct color_entity
+class color_entity
 {
+public:
 	material_type material;
 	unsigned char rgba[4]; // RGBA Array
 	unsigned char complement[4]; // RGBA Array

--- a/src/libldr/common.h
+++ b/src/libldr/common.h
@@ -8,11 +8,25 @@
 #define _LIBLDR_COMMON_H_
 
 #ifdef WIN32
+#ifdef MAKE_LIBLDR_LIB
 #define LIBLDR_EXPORT __declspec(dllexport)
+#else
+#define LIBLDR_EXPORT __declspec(dllimport)
+#endif
 #define DIRECTORY_SEPARATOR "\\"
 #else
 #define LIBLDR_EXPORT __attribute__ ((visibility("default")))
 #define DIRECTORY_SEPARATOR "/"
+#endif
+
+#ifdef WIN32
+#ifdef MAKE_LIBLDRAWRENDERER_LIB
+#define LIBLDRAWRENDERER_EXPORT __declspec(dllexport)
+#else
+#define LIBLDRAWRENDERER_EXPORT __declspec(dllimport)
+#endif
+#else
+#define LIBLDRAWRENDERER_EXPORT __attribute__ ((visibility("default")))
 #endif
 
 #include "exception.h"

--- a/src/libldr/exception.h
+++ b/src/libldr/exception.h
@@ -10,6 +10,10 @@
 #include <exception>
 #include <string>
 
+#ifndef __func__
+#define __func__ __FUNCTION__
+#endif
+
 namespace ldraw {
 
 class LIBLDR_EXPORT exception : public std::exception

--- a/src/renderer/CMakeLists.txt
+++ b/src/renderer/CMakeLists.txt
@@ -27,6 +27,7 @@ set(libldrawrenderer_HEADERS
 	renderer_opengl_retained.h
 	vbuffer_extension.h
 )
+add_definitions(-DMAKE_LIBLDRAWRENDERER_LIB)
 
 add_library(libldrawrenderer SHARED ${libldrawrenderer_SOURCES})
 target_link_libraries(libldrawrenderer libldr ${OPENGL_gl_LIBRARY} ${OPENGL_glu_LIBRARY})

--- a/src/renderer/mouse_rotation.h
+++ b/src/renderer/mouse_rotation.h
@@ -12,7 +12,7 @@
 namespace ldraw_renderer
 {
 
-class LIBLDR_EXPORT mouse_rotation
+class LIBLDRAWRENDERER_EXPORT mouse_rotation
 {
   public:
 	static const ldraw::matrix isometric_projection_matrix;

--- a/src/renderer/normal_extension.h
+++ b/src/renderer/normal_extension.h
@@ -20,7 +20,7 @@ namespace ldraw
 namespace ldraw_renderer
 {
 
-class LIBLDR_EXPORT normal_extension : public ldraw::extension
+class LIBLDRAWRENDERER_EXPORT normal_extension : public ldraw::extension
 {
   public:
 	normal_extension(ldraw::model *m, void *arg);

--- a/src/renderer/opengl_extension.cpp
+++ b/src/renderer/opengl_extension.cpp
@@ -6,6 +6,10 @@
 
 #include <cstring>
 
+#if defined(WIN32)
+#include <windows.h>
+#endif
+
 #include <GL/gl.h>
 
 #if defined(WIN32)
@@ -42,7 +46,7 @@ bool opengl_extension::is_supported() const
 opengl_extension::func_ptr opengl_extension::get_glext_proc(const char *procname)
 {
 #if defined(WIN32)
-	return wglGetProcAddress(procname);
+	return (opengl_extension::func_ptr) wglGetProcAddress(procname);
 #else
 	return glXGetProcAddress((const GLubyte *)procname);
 #endif

--- a/src/renderer/opengl_extension.h
+++ b/src/renderer/opengl_extension.h
@@ -12,7 +12,7 @@
 namespace ldraw_renderer
 {
 
-class LIBLDR_EXPORT opengl_extension
+class LIBLDRAWRENDERER_EXPORT opengl_extension
 {
   public:
 	typedef void (*func_ptr)();

--- a/src/renderer/opengl_extension_shader.h
+++ b/src/renderer/opengl_extension_shader.h
@@ -7,6 +7,10 @@
 #ifndef _RENDERER_OPENGL_EXTENSION_VSHADER_H_
 #define _RENDERER_OPENGL_EXTENSION_VSHADER_H_
 
+#if defined(WIN32)
+#include <windows.h>
+typedef char GLchar;
+#endif
 #include <GL/gl.h>
 
 #include <libldr/common.h>
@@ -16,7 +20,7 @@
 namespace ldraw_renderer
 {
 
-class LIBLDR_EXPORT opengl_extension_shader : public opengl_extension
+class LIBLDRAWRENDERER_EXPORT opengl_extension_shader : public opengl_extension
 {
   public:
 	static opengl_extension_shader* self();

--- a/src/renderer/opengl_extension_vbo.h
+++ b/src/renderer/opengl_extension_vbo.h
@@ -7,6 +7,10 @@
 #ifndef _RENDERER_OPENGL_EXTENSION_VBO_H_
 #define _RENDERER_OPENGL_EXTENSION_VBO_H_
 
+#if defined(WIN32)
+#include <windows.h>
+#endif
+
 #include <GL/gl.h>
 
 #include <libldr/common.h>
@@ -16,7 +20,7 @@
 namespace ldraw_renderer
 {
 
-class LIBLDR_EXPORT opengl_extension_vbo : public opengl_extension
+class LIBLDRAWRENDERER_EXPORT opengl_extension_vbo : public opengl_extension
 {
   public:
 	static opengl_extension_vbo* self();

--- a/src/renderer/parameters.h
+++ b/src/renderer/parameters.h
@@ -12,7 +12,7 @@
 namespace ldraw_renderer
 {
 
-class LIBLDR_EXPORT parameters
+class LIBLDRAWRENDERER_EXPORT parameters
 {
   public:
 	enum stud_rendering_mode { stud_regular, stud_line, stud_square };

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -28,7 +28,7 @@ class parameters;
 
 typedef std::list<std::pair<int, unsigned int> > selection_list;
 
-class LIBLDR_EXPORT render_filter
+class LIBLDRAWRENDERER_EXPORT render_filter
 {
   public:
 	virtual ~render_filter() {}
@@ -36,7 +36,7 @@ class LIBLDR_EXPORT render_filter
 	virtual bool query(const ldraw::model *m, int index, int depth) const = 0;
 };	
 
-class LIBLDR_EXPORT renderer
+class LIBLDRAWRENDERER_EXPORT renderer
 {
   public:
 	enum selection { selection_points, selection_bounding_boxes, selection_model_full };

--- a/src/renderer/renderer_opengl.cpp
+++ b/src/renderer/renderer_opengl.cpp
@@ -4,6 +4,9 @@
  *                                                                                   *
  * Author: (c)2006-2010 Park "segfault" J. K. <mastermind_at_planetmono_dot_org>     */
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #include <GL/gl.h>
 
 #include "opengl_extension_vbo.h"

--- a/src/renderer/renderer_opengl.h
+++ b/src/renderer/renderer_opengl.h
@@ -17,7 +17,7 @@ namespace ldraw_renderer
 class parameters;
 class renderer;
 
-class LIBLDR_EXPORT renderer_opengl : public renderer
+class LIBLDRAWRENDERER_EXPORT renderer_opengl : public renderer
 {
   public:
 	renderer_opengl(const parameters *params);
@@ -26,7 +26,7 @@ class LIBLDR_EXPORT renderer_opengl : public renderer
 	virtual void setup();
 };
 
-class LIBLDR_EXPORT renderer_opengl_factory
+class LIBLDRAWRENDERER_EXPORT renderer_opengl_factory
 {
   public:
 	enum rendering_mode { mode_immediate, mode_varray, mode_vbo };

--- a/src/renderer/renderer_opengl_immediate.cpp
+++ b/src/renderer/renderer_opengl_immediate.cpp
@@ -4,6 +4,10 @@
  *                                                                                   *
  * Author: (c)2006-2008 Park "segfault" J. K. <mastermind_at_planetmono_dot_org>     */
 
+#if defined(WIN32)
+#include <windows.h>
+#endif
+
 #include <GL/gl.h>
 #include <GL/glu.h>
 

--- a/src/renderer/renderer_opengl_immediate.h
+++ b/src/renderer/renderer_opengl_immediate.h
@@ -21,7 +21,7 @@ namespace ldraw
 {
     class bfc_state_tracker;
     class color;
-    struct color_entity;
+    class color_entity;
     class metrics;
 }
 
@@ -40,7 +40,7 @@ class parameters;
 
 /* OpenGL immediate mode rendering path (now deprecated) */
 
-class LIBLDR_EXPORT renderer_opengl_immediate : public renderer_opengl
+class LIBLDRAWRENDERER_EXPORT renderer_opengl_immediate : public renderer_opengl
 {
   public:
 	~renderer_opengl_immediate();

--- a/src/renderer/renderer_opengl_retained.cpp
+++ b/src/renderer/renderer_opengl_retained.cpp
@@ -4,6 +4,10 @@
  *                                                                                   *
  * Author: (c)2006-2008 Park "segfault" J. K. <mastermind_at_planetmono_dot_org>     */
 
+#if defined(WIN32)
+#include <windows.h>
+#endif
+
 #define GL_GLEXT_PROTOTYPES
 #include <GL/gl.h>
 #include <GL/glu.h>
@@ -147,10 +151,10 @@ void renderer_opengl_retained::render(ldraw::model *m, const render_filter *filt
 		
 		if (m_shader)
 			shader->glDisableVertexAttribArray(m_vs_color_location_verttype);
-		
+#if !defined(GL_VERSION_1_1)
 		if (m_vbo)
 			vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, 0);
-
+#endif
 		glDisableClientState(GL_COLOR_ARRAY);
 	}
 	
@@ -173,9 +177,11 @@ void renderer_opengl_retained::render_bounding_box(const ldraw::metrics &metrics
 
 	const float *bbox = 0L;
 	
+#if !defined(GL_VERSION_1_1)
 	if (m_vbo)
 		vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, m_vbo_bbox_lines);
 	else
+#endif
 		bbox = m_bbox_lines;
 	glVertexPointer(3, GL_FLOAT, 0, bbox);
 
@@ -183,8 +189,10 @@ void renderer_opengl_retained::render_bounding_box(const ldraw::metrics &metrics
 
 	glPopMatrix();
 
+#if !defined(GL_VERSION_1_1)
 	if (m_vbo)
 		vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, 0);
+#endif
 }
 
 void renderer_opengl_retained::render_bounding_box_filled(const ldraw::metrics &metrics)
@@ -203,9 +211,11 @@ void renderer_opengl_retained::render_bounding_box_filled(const ldraw::metrics &
 
 	const float *bbox = 0L;
 	
+#if !defined(GL_VERSION_1_1)
 	if (m_vbo)
 		vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, m_vbo_bbox_filled);
 	else
+#endif
 		bbox = m_bbox_filled;
 	glVertexPointer(3, GL_FLOAT, 0, bbox);
 
@@ -213,8 +223,10 @@ void renderer_opengl_retained::render_bounding_box_filled(const ldraw::metrics &
 
 	glPopMatrix();
 
+#if !defined(GL_VERSION_1_1)
 	if (m_vbo)
 		vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, 0);
+#endif
 }
 
 void renderer_opengl_retained::render_bounding_boxes(ldraw::model *m, const render_filter *filter)
@@ -246,8 +258,10 @@ bool renderer_opengl_retained::hit_test(float *projection_matrix, float *modelvi
 	GLint viewport[4];
 	GLuint selectionBuffer[4];
 
+#if !defined(GL_VERSION_1_1)
 	if (m_vbo)
 		opengl_extension_vbo::self()->glBindBuffer(GL_ARRAY_BUFFER_ARB, 0);
+#endif
 	
 	if (w == 0)
 		w = 1;
@@ -302,9 +316,10 @@ bool renderer_opengl_retained::hit_test(float *projection_matrix, float *modelvi
 		++i;
 	}
 
+#if !defined(GL_VERSION_1_1)
 	if (m_vbo)
 		opengl_extension_vbo::self()->glBindBuffer(GL_ARRAY_BUFFER_ARB, 0);
-
+#endif
 	if (i == 0)
 		return false;
 
@@ -319,9 +334,10 @@ selection_list renderer_opengl_retained::select(float *projection_matrix, float 
 	GLint hits, viewport[4];
 	GLuint selectionBuffer[4096];
 
+#if !defined(GL_VERSION_1_1)
 	if (m_vbo)
 		opengl_extension_vbo::self()->glBindBuffer(GL_ARRAY_BUFFER_ARB, 0);
-
+#endif
 	if (w == 0)
 		w = 1;
 	else if (w < 0)
@@ -442,6 +458,7 @@ void renderer_opengl_retained::init_shader()
 	opengl_extension_shader *shader = opengl_extension_shader::self();
 
 	if (shader->is_supported()) {
+#if !defined(GL_VERSION_1_1)
 		m_shader = true;
 
 		m_vs_color_program = shader->glCreateProgram();
@@ -461,6 +478,7 @@ void renderer_opengl_retained::init_shader()
 		m_vs_color_location_rgba = shader->glGetUniformLocation(m_vs_color_program, "rgba");
 		m_vs_color_location_complement = shader->glGetUniformLocation(m_vs_color_program, "complement");
 		m_vs_color_location_verttype = shader->glGetAttribLocation(m_vs_color_program, "verttype");
+#endif
 	} else {
 		m_shader = false;
 	}
@@ -471,6 +489,7 @@ void renderer_opengl_retained::init_vbuffer()
 	opengl_extension_vbo *vbo = opengl_extension_vbo::self();
 	
 	if (vbo->is_supported()) {
+#if !defined(GL_VERSION_1_1)
 		m_vbo = true;
 		
 		vbo->glGenBuffers(1, &m_vbo_bbox_lines);
@@ -483,6 +502,7 @@ void renderer_opengl_retained::init_vbuffer()
 		vbo->glBufferData(GL_ARRAY_BUFFER_ARB, sizeof(m_bbox_filled), m_bbox_filled, GL_STATIC_DRAW_ARB);
 
 		vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, 0);
+#endif
 	} else {
 		m_vbo = false;
 	}
@@ -529,6 +549,7 @@ void renderer_opengl_retained::render_recursive(ldraw::model *m, const render_fi
 		opengl_extension_shader *shader = opengl_extension_shader::self();
 		
 		if (m_shader) {
+#if !defined(GL_VERSION_1_1)
 			shader->glUseProgram(m_vs_color_program);
 			ldraw::color c(0);
 			if (m_colorstack.size() > 0)
@@ -540,21 +561,26 @@ void renderer_opengl_retained::render_recursive(ldraw::model *m, const render_fi
 			shader->glUniform4f(m_vs_color_location_rgba, cptr[0] / 255.0f, cptr[1] / 255.0f, cptr[2] / 255.0f, cptr[3] / 255.0f);
 			cptr = c.get_entity()->complement;
 			glUniform4f(m_vs_color_location_complement, cptr[0] / 255.0f, cptr[1] / 255.0f, cptr[2] / 255.0f, cptr[3] / 255.0f);
+#endif
 		}
 
 		glDisable(GL_LIGHTING);
 		
 		/* lines */
 		if (ve->count(vbuffer_extension::type_lines) > 0) {
+#if !defined(GL_VERSION_1_1)
 			if (m_vbo)
 				vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, ve->get_vbo_vertices(vbuffer_extension::type_lines));
+#endif
 			glVertexPointer(3, GL_FLOAT, 0, ve->get_vertex_array(vbuffer_extension::type_lines));
 			if (m_vbo) {
+#if !defined(GL_VERSION_1_1)
 				if (m_shader)
 					vbo_color = ve->get_vbo_colors(vbuffer_extension::type_lines);
 				else
 					vbo_color = ve->get_vbo_precolored(vbuffer_extension::type_lines, m_colorstack.top());
 				vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, vbo_color);
+#endif
 			}
 			if (m_shader)
 				color = ve->get_color_array(vbuffer_extension::type_lines);
@@ -585,15 +611,20 @@ void renderer_opengl_retained::render_recursive(ldraw::model *m, const render_fi
 			
 			/* triangles */
 			if (ve->count(vbuffer_extension::type_triangles) > 0) {
+#if !defined(GL_VERSION_1_1)
 				if (m_vbo)
 					vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, ve->get_vbo_vertices(vbuffer_extension::type_triangles));
+#endif
 				glVertexPointer(3, GL_FLOAT, 0, ve->get_vertex_array(vbuffer_extension::type_triangles));
 				if (shading) {
+#if !defined(GL_VERSION_1_1)
 					if (m_vbo)
 						vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, ve->get_vbo_normals(vbuffer_extension::type_triangles));
+#endif
 					glNormalPointer(GL_FLOAT, 0, ve->get_normal_array(vbuffer_extension::type_triangles));
 				}
 				
+#if !defined(GL_VERSION_1_1)
 				if (m_vbo) {
 					if (m_shader)
 						vbo_color = ve->get_vbo_colors(vbuffer_extension::type_triangles);
@@ -601,6 +632,7 @@ void renderer_opengl_retained::render_recursive(ldraw::model *m, const render_fi
 						vbo_color = ve->get_vbo_precolored(vbuffer_extension::type_triangles, m_colorstack.top());
 					vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, vbo_color);
 				}
+#endif
 				if (m_shader)
 					color = ve->get_color_array(vbuffer_extension::type_triangles);
 				else
@@ -611,14 +643,19 @@ void renderer_opengl_retained::render_recursive(ldraw::model *m, const render_fi
 			
 			/* quads */
 			if (ve->count(vbuffer_extension::type_quads) > 0) {
+#if !defined(GL_VERSION_1_1)
 				if (m_vbo)
 					vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, ve->get_vbo_vertices(vbuffer_extension::type_quads));
+#endif
 				glVertexPointer(3, GL_FLOAT, 0, ve->get_vertex_array(vbuffer_extension::type_quads));
 				if (shading) {
+#if !defined(GL_VERSION_1_1)
 					if (m_vbo)
 						vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, ve->get_vbo_normals(vbuffer_extension::type_quads));
+#endif
 					glNormalPointer(GL_FLOAT, 0, ve->get_normal_array(vbuffer_extension::type_quads));
 				}
+#if !defined(GL_VERSION_1_1)
 				if (m_vbo) {
 					if (m_shader)
 						vbo_color = ve->get_vbo_colors(vbuffer_extension::type_quads);
@@ -626,6 +663,7 @@ void renderer_opengl_retained::render_recursive(ldraw::model *m, const render_fi
 						vbo_color = ve->get_vbo_precolored(vbuffer_extension::type_quads, m_colorstack.top());
 					vbo->glBindBuffer(GL_ARRAY_BUFFER_ARB, vbo_color);
 				}
+#endif
 				if (m_shader)
 					color = ve->get_color_array(vbuffer_extension::type_quads);
 				else

--- a/src/renderer/renderer_opengl_retained.h
+++ b/src/renderer/renderer_opengl_retained.h
@@ -18,7 +18,7 @@ class parameters;
 
 /* OpenGL retained rendering path */
 
-class LIBLDR_EXPORT renderer_opengl_retained : public renderer_opengl
+class LIBLDRAWRENDERER_EXPORT renderer_opengl_retained : public renderer_opengl
 {
   public:
 	~renderer_opengl_retained();

--- a/src/renderer/vbuffer_extension.cpp
+++ b/src/renderer/vbuffer_extension.cpp
@@ -4,6 +4,9 @@
  *                                                                                   *
  * Author: (c)2006-2010 Park "segfault" J. K. <mastermind_at_planetmono_dot_org>     */
 
+#if defined(WIN32)
+#include <windows.h>
+#endif
 #include <GL/gl.h>
 
 #include <libldr/elements.h>
@@ -157,6 +160,7 @@ void vbuffer_extension::update()
 
 	opengl_extension_vbo *vbo = opengl_extension_vbo::self();
 	if (!m_params->force_vbuffer && vbo->is_supported()) {
+#if !defined(GL_VERSION_1_1)
 		m_isvbo = true;
 
 		// Create VBO and upload static data to VRAM if needed
@@ -196,6 +200,7 @@ void vbuffer_extension::update()
 
 		delete m_condparams;
 		m_condparams = 0L;
+#endif
 	} else {
 		m_isvbo = false;
 	}
@@ -428,8 +433,8 @@ void vbuffer_extension::fork_color(const ldraw::color &c)
 			colors[i] = 0L;
 		}
 	}
-
 	if (m_isvbo) {
+#if !defined(GL_VERSION_1_1)
 		GLuint *vbobuf = new GLuint[4];
 		vbo->glGenBuffers(4, vbobuf);
 		
@@ -448,6 +453,7 @@ void vbuffer_extension::fork_color(const ldraw::color &c)
 			delete b;
 		}
 		m_vbo_precolored[c] = vbobuf;
+#endif
 	} else {
 		if (m_precolored_buf.find(c) != m_precolored_buf.end()) {
 			float **b = m_precolored_buf[c];

--- a/src/renderer/vbuffer_extension.h
+++ b/src/renderer/vbuffer_extension.h
@@ -24,7 +24,7 @@ namespace ldraw
 namespace ldraw_renderer
 {
 
-class LIBLDR_EXPORT vbuffer_extension : public ldraw::extension
+class LIBLDRAWRENDERER_EXPORT vbuffer_extension : public ldraw::extension
 {
   public:
 	enum buffer_type

--- a/src/tests/modelviewer.cpp
+++ b/src/tests/modelviewer.cpp
@@ -1,6 +1,10 @@
 #include <cmath>
 #include <iostream>
 
+#if defined(WIN32)
+#include <windows.h>
+#endif
+
 #include <GL/gl.h>
 #include <GL/glu.h>
 

--- a/src/tests/modelviewer_glut.cpp
+++ b/src/tests/modelviewer_glut.cpp
@@ -2,6 +2,9 @@
 #include <cstring>
 #include <iostream>
 
+#if defined(WIN32)
+#include <windows.h>
+#endif
 #include <GL/glut.h>
 #include <GL/freeglut_ext.h>
 


### PR DESCRIPTION
Hi, 

in the branch I placed the win32 fixes for compiling konstruktor for KDE on windows with msvc2008

One of the main fixes is that windows.h should be included before including gl.h.
Another fix is that because libdrawrenender is a separate dll LIBLDR_KEXPORT could not be used. 

Having this patches in the public repository will make further release much  easier, so please merge them in. 

Regards
 Ralf 
